### PR TITLE
To Dev - DB Migration: Create 'olympics' table

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,10 @@ install:
 script:
   - npm test
 
-# before_script:
-#   - psql -c 'create database play_test;' -U postgres
-#   - knex migrate:latest --env test
+before_script:
+  - psql -c 'create database koroibos_test;' -U postgres
+  - knex migrate:latest --env test
+
+deploy:
+  run:
+    - knex migrate:latest

--- a/db/migrations/20200112121446_initial.js
+++ b/db/migrations/20200112121446_initial.js
@@ -1,0 +1,13 @@
+
+exports.up = function(knex) {
+  return knex.schema.createTable('olympics', (table) => {
+    table.increments('id').primary();
+    table.string('name').notNullable();
+
+    table.timestamps(true, true);
+  })
+};
+
+exports.down = function(knex) {
+  return knex.schema.dropTable('olympics');
+};

--- a/knexfile.js
+++ b/knexfile.js
@@ -1,0 +1,32 @@
+// Update with your config settings.
+
+module.exports = {
+
+  development: {
+    client: 'pg',
+    connection: 'postgres://localhost/koroibos_dev',
+    migrations: {
+      directory: './db/migrations'
+    },
+    seeds: {
+      directory: './db/seeds/dev'
+    },
+    useNullAsDefault: true
+  },
+  test: {
+    client: 'pg',
+    connection: 'postgres://localhost/koroibos_test',
+    migrations: {
+      directory: './db/migrations'
+    },
+    useNullAsDefault: true
+  },
+  production: {
+    client: 'pg',
+    connection: process.env.DATABASE_URL,
+    migrations: {
+      directory: './db/migrations'
+    },
+    useNullAsDefault: true
+  }
+};

--- a/tests/models/olympics.spec.js
+++ b/tests/models/olympics.spec.js
@@ -1,0 +1,24 @@
+var app = require('../../app');
+
+const env = process.env.NODE_ENV || 'test';
+const config = require('../../knexfile')[env];
+const DB = require('knex')(config);
+
+describe('Olympics table', () => {
+  beforeEach(async() => {
+    await DB.raw("TRUNCATE TABLE olympics CASCADE");
+  });
+
+  afterEach(async() => {
+    await DB.raw("TRUNCATE TABLE olympics CASCADE");
+  });
+
+  it('has an id and name', async() => {
+    let games = await DB('olympics')
+      .insert({ id: 1, title: '2016 Summer' })
+      .returning(['id', 'name'])
+
+    expect(games.id).toBe(1)
+    expect(games.name).toBe('2016 Summer')
+  })
+})

--- a/tests/models/olympics.spec.js
+++ b/tests/models/olympics.spec.js
@@ -15,10 +15,10 @@ describe('Olympics table', () => {
 
   it('has an id and name', async() => {
     let games = await DB('olympics')
-      .insert({ id: 1, title: '2016 Summer' })
+      .insert({ id: 1, name: '2016 Summer' })
       .returning(['id', 'name'])
 
-    expect(games.id).toBe(1)
-    expect(games.name).toBe('2016 Summer')
+    expect(games[0].id).toBe(1)
+    expect(games[0].name).toBe('2016 Summer')
   })
 })


### PR DESCRIPTION
## Issue Number: #9 

### Merge to
- [x] Dev branch
- [ ] Master branch

### Description of Changes
Olympics table is for the specific name of the Olypmic Games, e.g. '2016 Summer'

### Table:  'olympics'

### Relationship
- one-to-many: 'olympian_events'

### Attributes
| Column | Type | Options |
|---------|------|---------|
|  `id` |  integer | primary key |
| `name` | string | ex: '2016 Summer ' |

### Checklist
- [x] Tests written
- [x] README updated if necessary
- [ ] Tested in Postman / Staging 

### Additional Comments
NA