### PR TITLE
To Dev - DB Migration: Create 'sports' table

### DIFF
--- a/db/migrations/20200112150712_createSports.js
+++ b/db/migrations/20200112150712_createSports.js
@@ -1,0 +1,11 @@
+
+exports.up = function(knex) {
+  return knex.schema.createTable('sports', (table) => {
+    table.increments('id').primary();
+    table.string('sport').notNullable();
+  })
+};
+
+exports.down = function(knex) {
+  return knex.schema.dropTable('sports');
+};

--- a/tests/models/athlete.spec.js
+++ b/tests/models/athlete.spec.js
@@ -1,5 +1,3 @@
-var app = require('../../app');
-
 const config = require('../../knexfile')['test'];
 const DB = require('knex')(config);
 

--- a/tests/models/olympics.spec.js
+++ b/tests/models/olympics.spec.js
@@ -1,7 +1,4 @@
-var app = require('../../app');
-
-const env = process.env.NODE_ENV || 'test';
-const config = require('../../knexfile')[env];
+const config = require('../../knexfile')['test'];
 const DB = require('knex')(config);
 
 describe('Olympics table', () => {

--- a/tests/models/sport.spec.js
+++ b/tests/models/sport.spec.js
@@ -1,0 +1,21 @@
+const config = require('../../knexfile')['test'];
+const DB = require('knex')(config);
+
+describe('Olympics table', () => {
+  beforeEach(async () => {
+    await DB.raw("TRUNCATE TABLE sports CASCADE");
+  });
+
+  afterEach(async () => {
+    await DB.raw("TRUNCATE TABLE sports CASCADE");
+  });
+
+  it('has an id and name', async () => {
+    let sport = await DB('sports')
+      .insert({ 'id': 1, 'sport': 'Weightlifting' })
+      .returning(['id', 'sport'])
+
+    expect(sport[0].id).toBe(1)
+    expect(sport[0].sport).toBe('Weightlifting')
+  })
+})


### PR DESCRIPTION
## Issue Number: #10 

### Merge to
- [x] Dev branch
- [ ] Master branch

### Description of Changes
Sports are the higher-level category of olympic events. For example, the `sport` 'Weightlifting' has the `events` "Men's Heavyweight," "Women's Heavyweight," etc.

### Table:  'sports'

### Relationship
- one-to-many: 'events'

### Attributes
| Column | Type | Options |
|---------|------|---------|
|    `id`     | integer     | primary key        |
| `sport`  |  string    |         |


### Checklist
- [x] Tests written
- [x] README updated if necessary
- [ ] Tested in Postman / Staging 

### Additional Comments
NA