### PR TITLE
To Dev - DB Migration: Create 'events' table

### DIFF
--- a/db/migrations/20200112150712_createSports.js
+++ b/db/migrations/20200112150712_createSports.js
@@ -3,6 +3,8 @@ exports.up = function(knex) {
   return knex.schema.createTable('sports', (table) => {
     table.increments('id').primary();
     table.string('sport').notNullable();
+
+    table.timestamps(true, true);
   })
 };
 

--- a/db/migrations/20200112152814_createEvents.js
+++ b/db/migrations/20200112152814_createEvents.js
@@ -1,0 +1,18 @@
+
+exports.up = function(knex) {
+  return knex.schema.createTable('events', (table) => {
+    table.increments('id').primary();
+    table.integer('sport_id')
+      .unsigned()
+      .notNullable()
+      .references('sports.id')
+      .onDelete('CASCADE');
+    table.string('event').notNullable();
+
+    table.timestamps(true, true);
+  })
+};
+
+exports.down = function(knex) {
+  return knex.schema.dropTable('events');
+};

--- a/tests/models/event.spec.js
+++ b/tests/models/event.spec.js
@@ -2,15 +2,15 @@ const config = require('../../knexfile')['test'];
 const DB = require('knex')(config);
 
 describe('Olympics table', () => {
-  beforeEach(async () => {
+  beforeEach(async() => {
     await DB.raw("TRUNCATE TABLE sports CASCADE");
   });
 
-  afterEach(async () => {
+  afterEach(async() => {
     await DB.raw("TRUNCATE TABLE sports CASCADE");
   });
 
-  it('has an id and name', async () => {
+  it('has an id and name', async() => {
     await DB('sports')
       .insert({ 'id': 1, 'sport': 'Weightlifting' })
     
@@ -18,7 +18,8 @@ describe('Olympics table', () => {
       .insert({
         'id': 1,
         'sport_id': 1,
-        'event': "Weightlifting Women's Super- Heavyweight" })
+        'event': "Weightlifting Women's Super- Heavyweight"
+      })
 
     let event = await DB('sports')
       .join('events', 'sports.id', '=', 'events.sport_id')
@@ -26,5 +27,28 @@ describe('Olympics table', () => {
     expect(event[0].sport).toBe('Weightlifting')
     expect(event[0].sport_id).toBe(1)
     expect(event[0].event).toBe("Weightlifting Women's Super- Heavyweight")
+  })
+
+  it('cascades on delete', async() => {
+    await DB('sports')
+      .insert({ 'id': 1, 'sport': 'Weightlifting' })
+
+    await DB('events')
+      .insert({
+        'id': 1,
+        'sport_id': 1,
+        'event': "Weightlifting Women's Super- Heavyweight"
+      })
+
+    var sports = await DB('sports')
+    var events = await DB('events')
+    expect(sports.length).toBe(1)
+    expect(events.length).toBe(1)
+
+    await DB('sports').del()
+    var sports = await DB('sports')
+    var events = await DB('events')
+    expect(sports.length).toBe(0)
+    expect(events.length).toBe(0)
   })
 })

--- a/tests/models/event.spec.js
+++ b/tests/models/event.spec.js
@@ -1,0 +1,30 @@
+const config = require('../../knexfile')['test'];
+const DB = require('knex')(config);
+
+describe('Olympics table', () => {
+  beforeEach(async () => {
+    await DB.raw("TRUNCATE TABLE sports CASCADE");
+  });
+
+  afterEach(async () => {
+    await DB.raw("TRUNCATE TABLE sports CASCADE");
+  });
+
+  it('has an id and name', async () => {
+    await DB('sports')
+      .insert({ 'id': 1, 'sport': 'Weightlifting' })
+    
+    await DB('events')
+      .insert({
+        'id': 1,
+        'sport_id': 1,
+        'event': "Weightlifting Women's Super- Heavyweight" })
+
+    let event = await DB('sports')
+      .join('events', 'sports.id', '=', 'events.sport_id')
+    
+    expect(event[0].sport).toBe('Weightlifting')
+    expect(event[0].sport_id).toBe(1)
+    expect(event[0].event).toBe("Weightlifting Women's Super- Heavyweight")
+  })
+})


### PR DESCRIPTION
## Issue Number: #11 

### Merge to
- [x] Dev branch
- [ ] Master branch

### Description of Changes
Events are the more specific sub-category of `sports`. They include men's and women's events, different distance races, weight classes, etc.

### Table:  'events'

### Relationships
- one-to-many: `olympian_events`
- many-to-one: `sports`

### Attributes
| Column | Type | Options |
|---------|------|---------|
| `id`        | integer     |  primary key       |
| `sport_id` | integer      | foreign key        |
| `event`      | string     |         |


### Checklist
- [x] Tests written
- [ ] README updated if necessary
- [ ] Tested in Postman / Staging 

### Additional Comments
Includes timestamps for 'sports' table. Already rolled back staging DB.