### PR TITLE
To Dev - New Endpoint: GET /api/v1/olympians?age={youngest/oldest}

### DIFF
--- a/routes/api/v1/olympians.js
+++ b/routes/api/v1/olympians.js
@@ -7,7 +7,7 @@ const {
 } = require('../../../utils/dbQueries');
 
 router.get('/', (request, response) => {
-  olympianIndex()
+  olympianIndex(request.query)
     .then((dbResult) => response.status(200).send({ olympians: dbResult }))
     .catch((error) => response.status(500).send({ error }))
 });

--- a/routes/api/v1/olympians.js
+++ b/routes/api/v1/olympians.js
@@ -2,9 +2,7 @@ var express = require('express');
 var router = express.Router();
 
 const DB = require('../../../utils/dbConnect');
-const {
-  olympianIndex
-} = require('../../../utils/dbQueries');
+const { olympianIndex } = require('../../../utils/dbQueries');
 
 router.get('/', (request, response) => {
   olympianIndex(request.query)

--- a/tests/requests/v1/olympians.spec.js
+++ b/tests/requests/v1/olympians.spec.js
@@ -104,4 +104,24 @@ describe('GET /api/v1/olympians', ()=>{
     expect(response.status).toBe(200);
     expect(response.body).toEqual(expected);
   })
+
+  it('can get the oldest olympian', async () => {
+    let expected = {
+      "olympians": [
+        {
+          "name": "Ciara Everard",
+          "team": "Ireland",
+          "age": 26,
+          "sport": "Athletics",
+          "total_medals_won": 1
+        }
+      ]
+    }
+
+    var response = await request(app)
+      .get('/api/v1/olympians?age=oldest');
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual(expected);
+  })
 })

--- a/tests/requests/v1/olympiansIndex.spec.js
+++ b/tests/requests/v1/olympiansIndex.spec.js
@@ -42,13 +42,6 @@ describe('GET /api/v1/olympians', ()=>{
         Medal: 'NA'
       }
     ]
-  });
-
-  afterEach(async () => {
-    await destroyAll();
-  });
-
-  it('example', async () => {
     let athlete = await createAthlete(data[0]);
     let olympics = await createOlympics(data[0]);
     let sport = await createSport(data[0]);
@@ -60,7 +53,13 @@ describe('GET /api/v1/olympians', ()=>{
     let sport2 = await createSport(data[1]);
     let event2 = await createEvent(data[1], sport2);
     await createAthleteEvent(data[1], athlete2, event2, olympics2);
+  });
 
+  afterEach(async () => {
+    await destroyAll();
+  });
+
+  it('can get all olympians with their total medals won', async () => {
     let expected = {
       "olympians": [
         {
@@ -81,6 +80,26 @@ describe('GET /api/v1/olympians', ()=>{
     }
     var response = await request(app)
       .get('/api/v1/olympians');
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual(expected);
+  })
+
+  it('can get the youngest olympian', async () => {
+    let expected = {
+      "olympians": [
+        {
+          "name": "Maha Abdalsalam",
+          "team": "Egypt",
+          "age": 20,
+          "sport": "Diving",
+          "total_medals_won": 0
+        }
+      ]
+    }
+
+    var response = await request(app)
+      .get('/api/v1/olympians?age=youngest');
 
     expect(response.status).toBe(200);
     expect(response.body).toEqual(expected);


### PR DESCRIPTION
## Issue Number: #2, #3

### Merge to
- [x] Dev branch
- [ ] Master branch

### Description of Changes
As a user, I should be able to send a GET request to /api/v1/olympians with the query param `?age=youngest`. A successful response would return the `name`, `team`, `age`, `sport`, and `total_medals_won` of the youngest athlete in the database`.

As a user, I should be able to send a GET request to /api/v1/olympians with the query param `?age=oldest`. A successful response would return the `name`, `team`, `age`, `sport`, and `total_medals_won` of the oldest athlete in the database.

### Example Request
```
GET /api/v1/olympians?age=youngest
```

### Success Response
```
Status: 200

{
  "olympians": [
    {
      "name": "Ana Iulia Dascl",
      "team": "Romania",
      "age": 13,
      "sport": "Swimming"
      "total_medals_won": 0
    }
  ]
}
```

### Example Request
```
GET /api/v1/olympians?age=oldest
```

### Success Response
```
Status: 200

{
  "olympians": [
    {
      "name": "Julie Brougham",
      "team": "New Zealand",
      "age": 62,
      "sport": "Equestrianism"
      "total_medals_won": 0
    }
  ]
}
```



### Checklist
- [x] Tests written
- [ ] README updated if necessary
- [x] Tested in Postman / Staging 

### Additional Comments
NA