### PR TITLE
To Dev - New Endpoint: GET api/v1/events

### DIFF
--- a/app.js
+++ b/app.js
@@ -7,6 +7,7 @@ const environment = process.env.NODE_ENV || 'development';
 const indexRouter = require('./routes/index');
 const olympiansRouter = require('./routes/api/v1/olympians')
 const statsRouter = require('./routes/api/v1/olympianStats')
+const eventsRouter = require('./routes/api/v1/events')
 
 var app = express();
 
@@ -18,5 +19,6 @@ app.use(express.static(path.join(__dirname, 'public')));
 app.use('/', indexRouter);
 app.use('/api/v1/olympians', olympiansRouter);
 app.use('/api/v1/olympian_stats', statsRouter);
+app.use('/api/v1/events', eventsRouter);
 
 module.exports = app;

--- a/models/event.js
+++ b/models/event.js
@@ -20,6 +20,14 @@ class Event extends Model {
       }
     }
   }
+
+  static get modifiers() {
+    return {
+      onlyEventName(builder) {
+        builder.select('event')
+      }
+    }
+  }
 }
 
 module.exports = Event;

--- a/models/event.js
+++ b/models/event.js
@@ -1,0 +1,25 @@
+const { Model } = require('objection')
+const Sport = require('./sport')
+const DB = require('../utils/dbConnect')
+Model.knex(DB)
+
+class Event extends Model {
+  static get tableName() {
+    return 'events';
+  }
+
+  static get relationMappings() {
+    return {
+      sport: {
+        relation: Model.BelongsToOneRelation,
+        modelClass: Sport,
+        join: {
+          from: 'sports.id',
+          to: 'events.sport_id'
+        }
+      }
+    }
+  }
+}
+
+module.exports = Event;

--- a/models/sport.js
+++ b/models/sport.js
@@ -1,0 +1,25 @@
+const { Model } = require('objection')
+const Event = require('./event')
+const DB = require('../utils/dbConnect')
+Model.knex(DB)
+
+class Sport extends Model {
+  static get tableName() {
+    return 'sports';
+  }
+
+  static get relationMappings() {
+    return {
+      events: {
+        relation: Model.HasManyRelation,
+        modelClass: Event,
+        join: {
+          from: 'sports.id',
+          to: 'events.sport_id'
+        }
+      }
+    }
+  }
+}
+
+module.exports = Sport;

--- a/package-lock.json
+++ b/package-lock.json
@@ -538,7 +538,6 @@
       "version": "6.10.2",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
       "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
-      "dev": true,
       "requires": {
         "fast-deep-equal": "^2.0.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -1329,6 +1328,11 @@
         }
       }
     },
+    "db-errors": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/db-errors/-/db-errors-0.2.3.tgz",
+      "integrity": "sha512-OOgqgDuCavHXjYSJoV2yGhv6SeG8nk42aoCSoyXLZUH7VwFG27rxbavU1z+VrZbZjphw5UkDQwUlD21MwZpUng=="
+    },
     "debug": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
@@ -1826,14 +1830,12 @@
     "fast-deep-equal": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
-      "dev": true
+      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
     },
     "fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "dev": true
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -3940,8 +3942,7 @@
     "json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
     "json-stringify-safe": {
       "version": "5.0.1",
@@ -4525,6 +4526,15 @@
         "isobject": "^3.0.1"
       }
     },
+    "objection": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/objection/-/objection-2.1.2.tgz",
+      "integrity": "sha512-55tkg1C8iFfsEz07N3peKXU4COve+jRTaUlSXAGlcC2Kk/7ONntREnwErQp+0483g7eexEbc8EJ7CDPu/RmYoQ==",
+      "requires": {
+        "ajv": "^6.10.2",
+        "db-errors": "^0.2.3"
+      }
+    },
     "on-finished": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
@@ -4936,8 +4946,7 @@
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "dev": true
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "qs": {
       "version": "6.7.0",
@@ -6137,7 +6146,6 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
       "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
-      "dev": true,
       "requires": {
         "punycode": "^2.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "knex": "~0.20.7",
     "morgan": "~1.9.1",
     "nodemon": "~2.0.2",
+    "objection": "~2.1.2",
     "pg": "~7.17.1"
   },
   "devDependencies": {

--- a/routes/api/v1/events.js
+++ b/routes/api/v1/events.js
@@ -1,0 +1,11 @@
+var express = require('express');
+var router = express.Router();
+
+const DB = require('../../../utils/dbConnect');
+// const { olympianIndex } = require('../../../utils/dbQueries');
+
+router.get('/', (request, response) => {
+  response.status(200).send({message: 'hi'})
+});
+
+module.exports = router;

--- a/routes/api/v1/events.js
+++ b/routes/api/v1/events.js
@@ -2,10 +2,12 @@ var express = require('express');
 var router = express.Router();
 
 const DB = require('../../../utils/dbConnect');
-// const { olympianIndex } = require('../../../utils/dbQueries');
+const { sportEvents } = require('../../../utils/dbQueries');
 
 router.get('/', (request, response) => {
-  response.status(200).send({message: 'hi'})
+  sportEvents()
+    .then((result) => response.status(200).send(result))
+    .catch((error) => response.status(500).send({ error }))
 });
 
 module.exports = router;

--- a/routes/api/v1/events.js
+++ b/routes/api/v1/events.js
@@ -7,7 +7,7 @@ const { sportEvents } = require('../../../utils/dbQueries');
 router.get('/', (request, response) => {
   sportEvents()
     .then((result) => response.status(200).send(result))
-    .catch((error) => response.status(500).send({ error }))
+    .catch((error) => response.status(500).send(error))
 });
 
 module.exports = router;

--- a/routes/api/v1/olympianStats.js
+++ b/routes/api/v1/olympianStats.js
@@ -7,7 +7,7 @@ const { olympianStats } = require('../../../utils/dbQueries');
 router.get('/', (request, response) => {
   olympianStats()
     .then((result) => response.status(200).send(result))
-    .catch((error) => response.status(500).send({ error }))
+    .catch((error) => response.status(500).send(error))
 })
 
 module.exports = router;

--- a/routes/api/v1/olympians.js
+++ b/routes/api/v1/olympians.js
@@ -7,7 +7,7 @@ const { olympianIndex } = require('../../../utils/dbQueries');
 router.get('/', (request, response) => {
   olympianIndex(request.query)
     .then((dbResult) => response.status(200).send({ olympians: dbResult }))
-    .catch((error) => response.status(500).send({ error }))
+    .catch((error) => response.status(500).send(error))
 });
 
 module.exports = router;

--- a/tests/requests/v1/events.spec.js
+++ b/tests/requests/v1/events.spec.js
@@ -1,0 +1,47 @@
+const request = require("supertest");
+const app = require('../../../app');
+const DB = require('../../../utils/dbConnect');
+const { destroyAll } = require('../../../utils/dbHelpers');
+
+describe('GET /api/v1/events', () => {
+  beforeEach(async () => {
+    await destroyAll();
+  })
+
+  afterEach(async () => {
+    await destroyAll();
+  })
+
+  it('returns every sport and its associated events', async () => {
+    let sport1 = await DB('sports').insert({ sport: 'Athletics' }).returning('*');
+    let sport2 = await DB('sports').insert({ sport: 'Gymnastics' }).returning('*');
+    await DB('events').insert({ event: 'Athletics Women\'s Marathon', sport_id: sport1[0].id });
+    await DB('events').insert({ event: 'Athletics Men\'s Pole Vault', sport_id: sport1[0].id });
+    await DB('events').insert({ event: 'Gymnastics Women\'s Balance Beam', sport_id: sport2[0].id });
+    await DB('events').insert({ event: 'Gymnastics Men\'s Rings', sport_id: sport2[0].id });
+
+    let expected = {
+      events: [
+        {
+          sport: 'Athletics',
+          events: [
+            'Athletics Men\'s Pole Vault',
+            'Athletics Women\'s Marathon'
+          ]
+        },
+        {
+          sport: 'Gymnastics',
+          events: [
+            'Gymnastics Men\'s Rings',
+            'Gymnastics Women\'s Balance Beam'
+          ]
+        }
+      ]
+    }
+
+    let response = await request(app).get('/api/v1/events');
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual(expected);
+  })
+})

--- a/tests/requests/v1/events.spec.js
+++ b/tests/requests/v1/events.spec.js
@@ -25,15 +25,15 @@ describe('GET /api/v1/events', () => {
         {
           sport: 'Athletics',
           events: [
-            'Athletics Men\'s Pole Vault',
-            'Athletics Women\'s Marathon'
+            'Athletics Women\'s Marathon',
+            'Athletics Men\'s Pole Vault'
           ]
         },
         {
           sport: 'Gymnastics',
           events: [
-            'Gymnastics Men\'s Rings',
-            'Gymnastics Women\'s Balance Beam'
+            'Gymnastics Women\'s Balance Beam',
+            'Gymnastics Men\'s Rings'
           ]
         }
       ]
@@ -43,8 +43,8 @@ describe('GET /api/v1/events', () => {
 
     expect(response.status).toBe(200);
     expect(response.body).toHaveProperty('events')
-    expect(response.body.events).toHaveProperty('sport')
-    expect(response.body.events).toHaveProperty('events')
-    // expect(response.body).toEqual(expected);
+    expect(response.body.events[0]).toHaveProperty('sport')
+    expect(response.body.events[0]).toHaveProperty('events')
+    expect(response.body).toEqual(expected);
   })
 })

--- a/tests/requests/v1/events.spec.js
+++ b/tests/requests/v1/events.spec.js
@@ -42,6 +42,9 @@ describe('GET /api/v1/events', () => {
     let response = await request(app).get('/api/v1/events');
 
     expect(response.status).toBe(200);
-    expect(response.body).toEqual(expected);
+    expect(response.body).toHaveProperty('events')
+    expect(response.body.events).toHaveProperty('sport')
+    expect(response.body.events).toHaveProperty('events')
+    // expect(response.body).toEqual(expected);
   })
 })

--- a/tests/requests/v1/events.spec.js
+++ b/tests/requests/v1/events.spec.js
@@ -25,15 +25,15 @@ describe('GET /api/v1/events', () => {
         {
           sport: 'Athletics',
           events: [
-            'Athletics Women\'s Marathon',
-            'Athletics Men\'s Pole Vault'
+            'Athletics Men\'s Pole Vault',
+            'Athletics Women\'s Marathon'
           ]
         },
         {
           sport: 'Gymnastics',
           events: [
-            'Gymnastics Women\'s Balance Beam',
-            'Gymnastics Men\'s Rings'
+            'Gymnastics Men\'s Rings',
+            'Gymnastics Women\'s Balance Beam'
           ]
         }
       ]

--- a/tests/requests/v1/olympians.spec.js
+++ b/tests/requests/v1/olympians.spec.js
@@ -13,7 +13,7 @@ const {
 } = require('../../../utils/dbHelpers');
 
 
-describe('GET /api/v1/olympians', ()=>{
+describe('GET /api/v1/olympians', () => {
   beforeEach(async () => {
     await destroyAll();
     data = [

--- a/utils/dbQueries.js
+++ b/utils/dbQueries.js
@@ -47,7 +47,13 @@ async function sportEvents() {
   try {
     let result = await Sport.query()
       .withGraphJoined('events(onlyEventName)')
-      .select('sport', 'events');
+      .select('sport', 'events')
+      .then(events => events.map(obj => {
+        return {
+          sport: obj.sport,
+          events: obj.events.map(e => e.event)
+        }
+      }));
 
     return { events: result };
   } catch(err) {

--- a/utils/dbQueries.js
+++ b/utils/dbQueries.js
@@ -1,4 +1,6 @@
 const DB = require('./dbConnect')
+const { withGraphJoined } = require('objection')
+const Sport = require('../models/sport')
 
 async function olympianIndex(params) {
   try {
@@ -41,6 +43,18 @@ async function olympianStats() {
   }
 }
 
+async function sportEvents() {
+  try {
+    let result = await Sport.query()
+      .withGraphJoined('events(onlyEventName)')
+      .select('sport', 'events');
+
+    return { events: result };
+  } catch(err) {
+    console.log(err)
+  }
+}
+
 async function _countAthletes() {
   let result = await DB('athletes').count('*')
   return parseInt(result[0].count)
@@ -77,5 +91,6 @@ function _addToQuery(params) {
 
 module.exports = {
   olympianIndex: olympianIndex,
-  olympianStats: olympianStats
+  olympianStats: olympianStats,
+  sportEvents: sportEvents
 }

--- a/utils/dbQueries.js
+++ b/utils/dbQueries.js
@@ -51,7 +51,7 @@ async function sportEvents() {
       .then(events => events.map(obj => {
         return {
           sport: obj.sport,
-          events: obj.events.map(e => e.event)
+          events: obj.events.map(e => e.event).sort()
         }
       }));
 


### PR DESCRIPTION
## Issue Number: #5 

### Merge to
- [x] Dev branch
- [ ] Master branch

### Description of Changes
As a user, I should be able to send a request to GET api/v1/events. It should return a list of each `sport` with a sub-list of each `event` associated with that sport.

### Example Request
```
GET /api/v1/events

{
  "events":
    [
      {
        "sport": "Archery",
        "events": [
          "Archery Men's Individual",
          "Archery Men's Team",
          "Archery Women's Individual",
          "Archery Women's Team"
        ]
      },
      {
        "sport": "Badminton",
        "events": [
          "Badminton Men's Doubles",
          "Badminton Men's Singles",
          "Badminton Women's Doubles",
          "Badminton Women's Singles",
          "Badminton Mixed Doubles"
        ]
      },
      {...}
    ]
}
```

### Success Response
```
Status: 200

```


### Checklist
- [x] Tests written
- [ ] README updated if necessary
- [x] Tested in Postman / Staging 

### Additional Comments
NA